### PR TITLE
fix division with intergers

### DIFF
--- a/mean_average_precision/utils/bbox.py
+++ b/mean_average_precision/utils/bbox.py
@@ -46,4 +46,4 @@ def jaccard(box_a, box_b):
     area_a = area_a[:, np.newaxis]
     area_b = area_b[np.newaxis, :]
     union = area_a + area_b - inter
-    return inter / union
+    return inter.astype('float32') / union


### PR DESCRIPTION
If coordinates of bounding boxes are all integers, jaccard will return 0. After adding astype('float32') in line 49, the problem is solved.