### PR TITLE
Fixed negative intersection calculation 

### DIFF
--- a/mean_average_precision/utils/bbox.py
+++ b/mean_average_precision/utils/bbox.py
@@ -23,7 +23,11 @@ def intersect_area(box_a, box_b):
     min_xy = np.maximum(resized_A[:, :, :2], resized_B[:, :, :2])
 
     diff_xy = (max_xy - min_xy)
-    inter = np.clip(diff_xy, a_min=0, a_max=np.max(diff_xy))
+    inter = np.maximum(diff_xy, 0)
+    inter_max = np.max(diff_xy)
+    if inter_max > 0:
+        inter = np.minimum(inter_max, inter)
+    
     return inter[:, :, 0] * inter[:, :, 1]
 
 


### PR DESCRIPTION
Hey, using np.clip() doesnt verify a_min<a_max. That caused negative intersection calculations when max_diff was negative. I noticed it when I got IoU values above 1. I replaced np.clip() with separate minimum and maximum calculations.